### PR TITLE
Feat/helseid double auth

### DIFF
--- a/.nais/nais-dev.yaml
+++ b/.nais/nais-dev.yaml
@@ -11,9 +11,7 @@ spec:
     enforce:
       enabled: true
       excludePaths:
-        - /samarbeidspartner/sykmelding/fhir/launch
-        - /samarbeidspartner/sykmelding/fhir/callback
-        - /samarbeidspartner/sykmelding/fhir/error/**
+        - /samarbeidspartner/sykmelding/fhir/**
         - /samarbeidspartner/sykmelding/api/**
   ingresses:
     - 'https://www.ekstern.dev.nav.no/samarbeidspartner/sykmelding'

--- a/.nais/nais-dev.yaml
+++ b/.nais/nais-dev.yaml
@@ -11,7 +11,9 @@ spec:
     enforce:
       enabled: true
       excludePaths:
-        - /samarbeidspartner/sykmelding/fhir/**
+        - /samarbeidspartner/sykmelding/fhir/launch
+        - /samarbeidspartner/sykmelding/fhir/callback
+        - /samarbeidspartner/sykmelding/fhir/error/**
         - /samarbeidspartner/sykmelding/api/**
   ingresses:
     - 'https://www.ekstern.dev.nav.no/samarbeidspartner/sykmelding'

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "syk-inn",
     "version": "0.1.0",
     "private": true,
-    "packageManager": "yarn@4.14.1",
+    "packageManager": "yarn@4.15.0",
     "engines": {
         "node": "24"
     },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "syk-inn",
     "version": "0.1.0",
     "private": true,
-    "packageManager": "yarn@4.15.0",
+    "packageManager": "yarn@4.14.1",
     "engines": {
         "node": "24"
     },

--- a/src/app/(fhir)/fhir/(fhir-launched)/[patientId]/layout.tsx
+++ b/src/app/(fhir)/fhir/(fhir-launched)/[patientId]/layout.tsx
@@ -20,6 +20,7 @@ import { FhirModeProvider } from '@core/providers/Modes'
 import { createFhirPaths } from '@core/providers/ModePaths'
 import FeedbackButton from '@components/feedback/FeedbackButton'
 import { hasAcceptedBruksvilkar } from '@core/services/bruksvilkar/bruksvilkar-service'
+import { getHelseIdAccessToken, getHelseIdIdToken } from '@data-layer/helseid/token/tokens'
 
 import { NoPractitionerSession, NoValidPatient } from './launched-errors'
 
@@ -95,6 +96,16 @@ async function getRootFhirData(currentPatientId: string): Promise<RootFhirData> 
         if ('error' in readyClient) {
             failSpan.silently(span, readyClient.error)
             return { error: 'NO_SESSION' }
+        }
+
+        try {
+            const helseIdAccessToken = await getHelseIdAccessToken()
+            const helseIdIdToken = await getHelseIdIdToken()
+            logger.info(
+                `[HelseID-double-auth-exp] HelseID tokens on FHIR path. access_token length: ${helseIdAccessToken.length}, id_token length: ${helseIdIdToken.length}`,
+            )
+        } catch (e) {
+            logger.warn(`[HelseID-double-auth-exp] No HelseID tokens on FHIR path: ${(e as Error).message}`)
         }
 
         const [practitioner, patient] = await Promise.all([readyClient.user.request(), readyClient.patient.request()])

--- a/src/core/data-layer/helseid/token/tokens.ts
+++ b/src/core/data-layer/helseid/token/tokens.ts
@@ -1,14 +1,14 @@
 import { headers } from 'next/headers'
 
 /**
- * Wonderwall (see README.md) exchanges it's own session ID for the actual HelseID access token. This
- * is not available in a other contexts other than a RSC or route handler.
+ * Wonderwall (see README.md) exchanges its own session ID for the actual HelseID access token. This
+ * is not available in another contexts other than an RSC or route handler.
  */
 export async function getHelseIdAccessToken(): Promise<string> {
     const bearerToken = (await headers()).get('Authorization')
 
     if (!bearerToken) {
-        throw new Error('No bearer token found')
+        throw new Error('No HelseID access_token found')
     }
 
     return bearerToken.replace('Bearer ', '')


### PR DESCRIPTION
Sikre alle paths utenom SMART launch flyten bak HelseID. Hvis dette fungerer skal nettleseren vise en 302 til helseid-sts.test.nhn.no og logge lengden på access_token og id_token hvis de finnes.